### PR TITLE
feat: symbols are now types

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ using IFizzPtr = std::unique_ptr<IFizz>;
 ```cpp
 
 namespace symbols {
-    inline extern inversify::Symbol<int> foo {};
-    inline extern inversify::Symbol<double> bar {};
-    inline extern inversify::Symbol<IFizzPtr> fizz {};
-    inline extern inversify::Symbol<std::function<IFizzPtr()>> fizzFactory {};
+    using foo = inversify::Symbol<int>;
+    using bar = inversify::Symbol<double>;
+    using fizz = inversify::Symbol<IFizzPtr>;
+    using fizzFactory = inversify::Symbol<std::function<IFizzPtr()>>;
 
-    inline extern inversify::Symbol<IFizzUniquePtr> autoFizzUnique {};
-    inline extern inversify::Symbol<IFizzSharedPtr> autoFizzShared {};
+    using autoFizzUnique = inversify::Symbol<std::function<IFizzUniquePtr>>;
+    using autoFizzShared = inversify::Symbol<std::function<IFizzSharedPtr>>;
 }
 
 ```
@@ -95,10 +95,13 @@ struct Fizz : IFizz {
     int counter_ { 0 };
 };
 
-inline static auto injectFizz = inversify::Injectable<Fizz>::inject(
-    symbols::foo,
-    symbols::bar
-);
+template <>
+struct inversify::Injectable<Fizz> {
+    using Inject = inversify::Inject<
+        symbols::foo,
+        symbols::bar
+    >;
+};
 
 ```
 
@@ -116,8 +119,8 @@ Constant bindings are always singletons.
 
 ```cpp
 
-container.bind(symbols::foo).toConstantValue(10);
-container.bind(symbols::bar).toConstantValue(1.618);
+container.bind<symbols::foo>().toConstantValue(10);
+container.bind<symbols::bar>().toConstantValue(1.618);
 
 ```
 
@@ -131,10 +134,10 @@ Singleton scope dynamic bindings cache the first resolution of the binding.
 
 ```cpp
 
-container.bind(symbols::fizz).toDynamicValue(
+container.bind<symbols::fizz>().toDynamicValue(
     [](const inversify::Context& ctx) {
-        auto foo = ctx.container.get(symbols::foo);
-        auto bar = ctx.container.get(symbols::bar);
+        auto foo = ctx.container.get<symbols::foo>();
+        auto bar = ctx.container.get<symbols::bar>();
 
         auto fizz = std::make_shared<Fizz>(foo, bar);
 
@@ -150,11 +153,11 @@ Dynamic bindings can be used to resolve factory functions.
 
 ```cpp
 
-container.bind(symbols::fizzFactory).toDynamicValue(
+container.bind<symbols::fizzFactory>().toDynamicValue(
     [](const inversify::Context& ctx) {
         return [&]() {
-            auto foo = ctx.container.get(symbols::foo);
-            auto bar = ctx.container.get(symbols::bar);
+            auto foo = ctx.container.get<symbols::foo>();
+            auto bar = ctx.container.get<symbols::bar>();
 
             auto fizz = std::make_shared<Fizz>(foo, bar);
 
@@ -173,8 +176,8 @@ Automatic bindings can generate instances, unique_ptr's, and shared_ptr's of a c
 
 ```cpp
 
-container.bind(symbols::autoFizzUnique).to<Fizz>();
-container.bind(symbols::autoFizzShared).to<Fizz>().inSingletonScope();
+container.bind<symbols::autoFizzUnique>().to<Fizz>();
+container.bind<symbols::autoFizzShared>().to<Fizz>().inSingletonScope();
 
 ```
 
@@ -182,20 +185,20 @@ container.bind(symbols::autoFizzShared).to<Fizz>().inSingletonScope();
 
 ```cpp
 
-auto bar = container.get(symbols::bar);
+auto bar = container.get<symbols::bar>();
 
-auto fizz = container.get(symbols::fizz);
+auto fizz = container.get<symbols::fizz>();
 fizz->buzz();
 
-auto fizzFactory = container.get(symbols::fizzFactory);
+auto fizzFactory = container.get<symbols::fizzFactory>();
 auto anotherFizz = fizzFactory();
 anotherFizz->buzz();
 
 
-auto autoFizzUnique = container.get(symbols::autoFizzUnique);
+auto autoFizzUnique = container.get<symbols::autoFizzUnique>();
 autoFizzUnique->buzz();
 
-auto autoFizzShared = container.get(symbols::autoFizzShared);
+auto autoFizzShared = container.get<symbols::autoFizzShared>();
 autoFizzShared->buzz();
 
 ```

--- a/example/BUILD
+++ b/example/BUILD
@@ -5,6 +5,7 @@ cc_library(
     name = "example_api",
     hdrs = glob([
         "api/*.hpp",
+        "src/*.hpp",
     ]),
     includes = [
         ".",

--- a/example/api/symbols.hpp
+++ b/example/api/symbols.hpp
@@ -9,7 +9,7 @@
 
 namespace inversify = mosure::inversify;
 namespace symbols {
-    inline extern inversify::Symbol<ILoggerPtr> logger {};
-    inline extern inversify::Symbol<IServicePtr> service {};
-    inline extern inversify::Symbol<ISettings> settings {};
+    using logger = inversify::Symbol<ILoggerPtr>;
+    using service = inversify::Symbol<IServicePtr>;
+    using settings = inversify::Symbol<ISettings>;
 }

--- a/example/src/logger.hpp
+++ b/example/src/logger.hpp
@@ -54,4 +54,9 @@ class Logger : public ILogger {
 };
 
 namespace inversify = mosure::inversify;
-inline static auto injectLogger = inversify::Injectable<Logger>::inject(symbols::settings);
+template <>
+struct inversify::Injectable<Logger> {
+    using Inject = inversify::Inject<
+        symbols::settings
+    >;
+};

--- a/example/src/main.cpp
+++ b/example/src/main.cpp
@@ -13,13 +13,13 @@ namespace inversify = mosure::inversify;
 int main() {
     inversify::Container container;
 
-    container.bind(symbols::logger).to<Logger>().inSingletonScope();
-    container.bind(symbols::service).to<Service>();
-    container.bind(symbols::settings).to<Settings>().inSingletonScope();
+    container.bind<symbols::logger>().to<Logger>().inSingletonScope();
+    container.bind<symbols::service>().to<Service>();
+    container.bind<symbols::settings>().to<Settings>().inSingletonScope();
 
     //container.bind<ILoggerPtr>(symbols::logger).to<MockLogger>().inSingletonScope();
 
-    container.get(symbols::service)->run();
+    container.get<symbols::service>()->run();
 
     return 0;
 }

--- a/example/src/mock_logger.hpp
+++ b/example/src/mock_logger.hpp
@@ -13,6 +13,3 @@ class MockLogger : public ILogger {
         void error(const std::string&) const override { };
         void log(LogLevel, const std::string&) const override { };
 };
-
-namespace inversify = mosure::inversify;
-inline static auto injectMockLogger = inversify::Injectable<MockLogger>::inject();

--- a/example/src/service.hpp
+++ b/example/src/service.hpp
@@ -25,4 +25,9 @@ class Service : public IService {
 };
 
 namespace inversify = mosure::inversify;
-inline static auto injectService = inversify::Injectable<Service>::inject(symbols::logger);
+template <>
+struct inversify::Injectable<Service> {
+    using Inject = inversify::Inject<
+        symbols::logger
+    >;
+};

--- a/example/src/settings.hpp
+++ b/example/src/settings.hpp
@@ -22,6 +22,3 @@ struct Settings : ISettings {
         }
     }
 };
-
-namespace inversify = mosure::inversify;
-inline static auto injectSettings = inversify::Injectable<Settings>::inject();

--- a/include/mosure/binding.hpp
+++ b/include/mosure/binding.hpp
@@ -46,11 +46,6 @@ namespace mosure::inversify {
     template <typename T>
     class Binding : public BindingTo<T> {
         public:
-            explicit Binding(const inversify::Symbol<T>& symbol)
-                :
-                symbol_(symbol)
-            { }
-
             T resolve(const Context& context) const {
                 if (!this->resolver_) {
                     throw inversify::exceptions::ResolutionException("inversify::Resolver not found. Malformed binding.");
@@ -58,9 +53,6 @@ namespace mosure::inversify {
 
                 return this->resolver_->resolve(context);
             }
-
-        private:
-            const inversify::Symbol<T>& symbol_;
     };
 
 }

--- a/include/mosure/injectable.hpp
+++ b/include/mosure/injectable.hpp
@@ -1,76 +1,27 @@
 #pragma once
 
-#include <memory>
 #include <tuple>
 #include <type_traits>
 
 #include <mosure/context.hpp>
-#include <mosure/factory.hpp>
 #include <mosure/meta.hpp>
 #include <mosure/symbol.hpp>
 
 
 namespace mosure::inversify {
 
-    template <typename ...Types>
-    inline constexpr bool valid_inject_types_v = std::conjunction_v<
-        meta::is_specialization<Types, Symbol>...
-    >;
+    template <typename... Dependencies>
+    struct Inject {
+        static_assert(meta::valid_inject_types_v<Dependencies...>, "inversify::Injectable dependencies must be of type inversify::Symbol");
+
+        inline static auto resolve(const inversify::Context& context) {
+            return std::make_tuple(context.container.get<Dependencies>()...);
+        }
+    };
 
     template <typename Implementation>
-    class Injectable {
-        public:
-            inline static inversify::Factory<Implementation> factory;
-            inline static inversify::Factory<std::unique_ptr<Implementation>> factory_unique;
-            inline static inversify::Factory<std::shared_ptr<Implementation>> factory_shared;
-
-            template <typename... Dependencies>
-            inline static Injectable inject(Dependencies... dependencies) {
-                static_assert(valid_inject_types_v<Dependencies...>, "inversify::Injectable dependencies must be of type inversify::Symbol");
-
-                factory = [
-                    deps = std::make_tuple(dependencies...)
-                ](const inversify::Context& context) mutable {
-                    auto expansion = [&context](auto&& ... deps){
-                        auto args = std::make_tuple(resolve_dependency(context, deps)...);
-
-                        return std::make_from_tuple<Implementation>(args);
-                    };
-
-                    return std::apply(expansion, std::move(deps));
-                };
-
-                factory_unique = [
-                    deps = std::make_tuple(dependencies...)
-                ](const inversify::Context& context) mutable {
-                    auto expansion = [&context](auto&& ... deps){
-                        return std::make_unique<Implementation>(resolve_dependency(context, deps)...);
-                    };
-
-                    return std::apply(expansion, std::move(deps));
-                };
-
-                factory_shared = [
-                    deps = std::make_tuple(dependencies...)
-                ](const inversify::Context& context) mutable {
-                    auto expansion = [&context](auto&& ... deps){
-                        return std::make_shared<Implementation>(resolve_dependency(context, deps)...);
-                    };
-
-                    return std::apply(expansion, std::move(deps));
-                };
-
-                return Injectable {};
-            }
-
-        private:
-            template <typename Dependency>
-            inline static typename Dependency::value resolve_dependency(const inversify::Context& context, Dependency dep) {
-                using Interface = typename Dependency::value;
-                auto symbol = static_cast<Symbol<Interface>>(dep);
-
-                return context.container.get(symbol);
-            }
+    struct Injectable {
+        using Inject = inversify::Inject<>;
     };
 
 }

--- a/include/mosure/interfaces/icontainer.hpp
+++ b/include/mosure/interfaces/icontainer.hpp
@@ -14,17 +14,17 @@ namespace mosure::inversify {
     class IContainer {
         public:
             template <typename T>
-            inversify::BindingTo<T>& bind(const inversify::Symbol<T>& type) {
+            inversify::BindingTo<typename T::value>& bind() {
                 auto crtpImplementation = static_cast<Implementation const *>(this);
 
-                return crtpImplementation->bind(type);
+                return crtpImplementation->template bind<T>();
             }
 
             template <typename T>
-            T get(const inversify::Symbol<T>& type) const {
+            typename T::value get() const {
                 auto crtpImplementation = static_cast<Implementation const *>(this);
 
-                return crtpImplementation->get(type);
+                return crtpImplementation->template get<T>();
             }
     };
 

--- a/include/mosure/inversify.hpp
+++ b/include/mosure/inversify.hpp
@@ -35,6 +35,7 @@ SOFTWARE.
 #include <string>           // string
 #include <unordered_map>    // unordered_map
 #include <tuple>            // make_from_tuple, tuple
+#include <typeinfo>         // typeid
 #include <type_traits>      // apply, conjunction_v, false_type, true_type
 #include <utility>          // make_pair
 

--- a/include/mosure/meta.hpp
+++ b/include/mosure/meta.hpp
@@ -12,4 +12,12 @@ namespace mosure::inversify::meta {
     template <template <class...> class Template, class... Args>
     struct is_specialization<Template<Args...>, Template> : std::true_type { };
 
+    template <typename ...Types>
+    inline constexpr bool valid_inject_types_v = std::conjunction_v<
+        meta::is_specialization<Types, Symbol>...
+    >;
+
+    template <typename T>
+    using value_t = typename T::value;
+
 }

--- a/include/mosure/symbol.hpp
+++ b/include/mosure/symbol.hpp
@@ -1,19 +1,14 @@
 #pragma once
 
-#include <iostream>
+#include <type_traits>
 
 
 namespace mosure::inversify {
 
-    namespace {
-        inline static int counter = 0;
-    }
-
     template <typename Interface>
     struct Symbol {
-        Symbol() : id(counter++) { }
+        static_assert(!std::is_abstract<Interface>(), "inversify::Container cannot bind/get abstract class value (use a smart pointer instead).");
 
-        const int id;
         using value = Interface;
     };
 

--- a/single_include/mosure/inversify.hpp
+++ b/single_include/mosure/inversify.hpp
@@ -35,6 +35,7 @@ SOFTWARE.
 #include <string>           // string
 #include <unordered_map>    // unordered_map
 #include <tuple>            // make_from_tuple, tuple
+#include <typeinfo>         // typeid
 #include <type_traits>      // apply, conjunction_v, false_type, true_type
 #include <utility>          // make_pair
 
@@ -55,20 +56,15 @@ SOFTWARE.
 // #include <mosure/symbol.hpp>
 
 
-#include <iostream>
+#include <type_traits>
 
 
 namespace mosure::inversify {
 
-    namespace {
-        inline static int counter = 0;
-    }
-
     template <typename Interface>
     struct Symbol {
-        Symbol() : id(counter++) { }
+        static_assert(!std::is_abstract<Interface>(), "inversify::Container cannot bind/get abstract class value (use a smart pointer instead).");
 
-        const int id;
         using value = Interface;
     };
 
@@ -85,17 +81,17 @@ namespace mosure::inversify {
     class IContainer {
         public:
             template <typename T>
-            inversify::BindingTo<T>& bind(const inversify::Symbol<T>& type) {
+            inversify::BindingTo<typename T::value>& bind() {
                 auto crtpImplementation = static_cast<Implementation const *>(this);
 
-                return crtpImplementation->bind(type);
+                return crtpImplementation->template bind<T>();
             }
 
             template <typename T>
-            T get(const inversify::Symbol<T>& type) const {
+            typename T::value get() const {
                 auto crtpImplementation = static_cast<Implementation const *>(this);
 
-                return crtpImplementation->get(type);
+                return crtpImplementation->template get<T>();
             }
     };
 
@@ -134,6 +130,7 @@ namespace mosure::inversify {
 
 #include <atomic>
 #include <memory>
+#include <tuple>
 #include <type_traits>
 
 // #include <mosure/context.hpp>
@@ -143,13 +140,10 @@ namespace mosure::inversify {
 // #include <mosure/injectable.hpp>
 
 
-#include <memory>
 #include <tuple>
 #include <type_traits>
 
 // #include <mosure/context.hpp>
-
-// #include <mosure/factory.hpp>
 
 // #include <mosure/meta.hpp>
 
@@ -166,6 +160,14 @@ namespace mosure::inversify::meta {
     template <template <class...> class Template, class... Args>
     struct is_specialization<Template<Args...>, Template> : std::true_type { };
 
+    template <typename ...Types>
+    inline constexpr bool valid_inject_types_v = std::conjunction_v<
+        meta::is_specialization<Types, Symbol>...
+    >;
+
+    template <typename T>
+    using value_t = typename T::value;
+
 }
 
 // #include <mosure/symbol.hpp>
@@ -174,65 +176,18 @@ namespace mosure::inversify::meta {
 
 namespace mosure::inversify {
 
-    template <typename ...Types>
-    inline constexpr bool valid_inject_types_v = std::conjunction_v<
-        meta::is_specialization<Types, Symbol>...
-    >;
+    template <typename... Dependencies>
+    struct Inject {
+        static_assert(meta::valid_inject_types_v<Dependencies...>, "inversify::Injectable dependencies must be of type inversify::Symbol");
+
+        inline static auto resolve(const inversify::Context& context) {
+            return std::make_tuple(context.container.get<Dependencies>()...);
+        }
+    };
 
     template <typename Implementation>
-    class Injectable {
-        public:
-            inline static inversify::Factory<Implementation> factory;
-            inline static inversify::Factory<std::unique_ptr<Implementation>> factory_unique;
-            inline static inversify::Factory<std::shared_ptr<Implementation>> factory_shared;
-
-            template <typename... Dependencies>
-            inline static Injectable inject(Dependencies... dependencies) {
-                static_assert(valid_inject_types_v<Dependencies...>, "inversify::Injectable dependencies must be of type inversify::Symbol");
-
-                factory = [
-                    deps = std::make_tuple(dependencies...)
-                ](const inversify::Context& context) mutable {
-                    auto expansion = [&context](auto&& ... deps){
-                        auto args = std::make_tuple(resolve_dependency(context, deps)...);
-
-                        return std::make_from_tuple<Implementation>(args);
-                    };
-
-                    return std::apply(expansion, std::move(deps));
-                };
-
-                factory_unique = [
-                    deps = std::make_tuple(dependencies...)
-                ](const inversify::Context& context) mutable {
-                    auto expansion = [&context](auto&& ... deps){
-                        return std::make_unique<Implementation>(resolve_dependency(context, deps)...);
-                    };
-
-                    return std::apply(expansion, std::move(deps));
-                };
-
-                factory_shared = [
-                    deps = std::make_tuple(dependencies...)
-                ](const inversify::Context& context) mutable {
-                    auto expansion = [&context](auto&& ... deps){
-                        return std::make_shared<Implementation>(resolve_dependency(context, deps)...);
-                    };
-
-                    return std::apply(expansion, std::move(deps));
-                };
-
-                return Injectable {};
-            }
-
-        private:
-            template <typename Dependency>
-            inline static typename Dependency::value resolve_dependency(const inversify::Context& context, Dependency dep) {
-                using Interface = typename Dependency::value;
-                auto symbol = static_cast<Symbol<Interface>>(dep);
-
-                return context.container.get(symbol);
-            }
+    struct Injectable {
+        using Inject = inversify::Inject<>;
     };
 
 }
@@ -298,11 +253,7 @@ namespace mosure::inversify {
     class AutoResolver<T, U> : public Resolver<T> {
         public:
             T resolve(const inversify::Context& context) override {
-                if (!inversify::Injectable<U>::factory_unique) {
-                    throw inversify::exceptions::ResolutionException("inversify::AutoResolver could not find factory. Is the binding correct?");
-                }
-
-                return inversify::Injectable<U>::factory(context);
+                return std::make_from_tuple<U>(inversify::Injectable<U>::Inject::resolve(context));
             }
     };
 
@@ -314,11 +265,11 @@ namespace mosure::inversify {
     class AutoResolver<std::unique_ptr<T>, U> : public Resolver<std::unique_ptr<T>> {
         public:
             std::unique_ptr<T> resolve(const inversify::Context& context) override {
-                if (!inversify::Injectable<U>::factory_unique) {
-                    throw inversify::exceptions::ResolutionException("inversify::AutoResolver could not find unique_ptr factory. Is the binding correct?");
-                }
+                auto expansion = [&context](auto&& ... deps){
+                    return std::make_unique<U>(deps...);
+                };
 
-                return inversify::Injectable<U>::factory_unique(context);
+                return std::apply(expansion, std::move(inversify::Injectable<U>::Inject::resolve(context)));
             }
     };
 
@@ -330,11 +281,11 @@ namespace mosure::inversify {
     class AutoResolver<std::shared_ptr<T>, U> : public Resolver<std::shared_ptr<T>> {
         public:
             std::shared_ptr<T> resolve(const inversify::Context& context) override {
-                if (!inversify::Injectable<U>::factory_shared) {
-                    throw inversify::exceptions::ResolutionException("inversify::AutoResolver could not find shared_ptr factory. Is the binding correct?");
-                }
+                auto expansion = [&context](auto&& ... deps){
+                    return std::make_shared<U>(deps...);
+                };
 
-                return inversify::Injectable<U>::factory_shared(context);
+                return std::apply(expansion, std::move(inversify::Injectable<U>::Inject::resolve(context)));
             }
     };
 
@@ -403,11 +354,6 @@ namespace mosure::inversify {
     template <typename T>
     class Binding : public BindingTo<T> {
         public:
-            explicit Binding(const inversify::Symbol<T>& symbol)
-                :
-                symbol_(symbol)
-            { }
-
             T resolve(const Context& context) const {
                 if (!this->resolver_) {
                     throw inversify::exceptions::ResolutionException("inversify::Resolver not found. Malformed binding.");
@@ -415,9 +361,6 @@ namespace mosure::inversify {
 
                 return this->resolver_->resolve(context);
             }
-
-        private:
-            const inversify::Symbol<T>& symbol_;
     };
 
 }
@@ -426,6 +369,7 @@ namespace mosure::inversify {
 
 
 #include <any>
+#include <typeinfo>
 #include <unordered_map>
 #include <utility>
 
@@ -458,36 +402,38 @@ namespace mosure::inversify {
     class Container : public inversify::IContainer<Container> {
         public:
             template <typename T>
-            inversify::BindingTo<T>& bind(const inversify::Symbol<T>& type) {
-                static_assert(!std::is_abstract<T>(), "inversify::Container cannot bind/get abstract class value (use a smart pointer instead).");
+            inversify::BindingTo<typename T::value>& bind() {
+                auto binding = inversify::Binding<typename T::value>();
 
-                auto binding = inversify::Binding(type);
+                auto key = typeid(T).hash_code();
 
-                auto lookup = bindings_.find(type.id);
+                auto lookup = bindings_.find(key);
                 if (lookup != bindings_.end()) {
-                    bindings_.erase(type.id);
+                    bindings_.erase(key);
                 }
 
-                auto pair = std::make_pair(type.id, std::any(binding));
+                auto pair = std::make_pair(key, std::any(binding));
                 bindings_.insert(pair);
 
-                return std::any_cast<inversify::Binding<T>&>(bindings_.at(type.id));
+                return std::any_cast<inversify::Binding<typename T::value>&>(bindings_.at(key));
             }
 
             template <typename T>
-            T get(const inversify::Symbol<T>& type) const {
-                auto symbolBinding = bindings_.find(type.id);
+            typename T::value get() const {
+                auto key = typeid(T).hash_code();
+
+                auto symbolBinding = bindings_.find(key);
                 if (symbolBinding == bindings_.end()) {
                     throw inversify::exceptions::SymbolException();
                 }
 
-                auto binding = std::any_cast<inversify::Binding<T>>(symbolBinding->second);
+                auto binding = std::any_cast<inversify::Binding<typename T::value>>(symbolBinding->second);
 
                 return binding.resolve(context_);
             }
 
         private:
-            std::unordered_map<int, std::any> bindings_ { };
+            std::unordered_map<std::size_t, std::any> bindings_ { };
             inversify::Context context_ { *this };
     };
 

--- a/test/auto_resolve.cpp
+++ b/test/auto_resolve.cpp
@@ -14,13 +14,13 @@ SCENARIO("container resolves automatic values", "[resolve]") {
     GIVEN("A container with automatic unique_ptr binding") {
         inversify::Container container;
 
-        container.bind(symbols::foo).toConstantValue(10);
-        container.bind(symbols::bar).toConstantValue(1.618);
+        container.bind<symbols::foo>().toConstantValue(10);
+        container.bind<symbols::bar>().toConstantValue(1.618);
 
-        container.bind(symbols::autoFizzUnique).to<Fizz>();
+        container.bind<symbols::autoFizzUnique>().to<Fizz>();
 
         WHEN("the dependency is resolved") {
-            auto result = container.get(symbols::autoFizzUnique);
+            auto result = container.get<symbols::autoFizzUnique>();
             auto foo = result->buzz();
 
             THEN("the correct value is returned") {
@@ -30,8 +30,8 @@ SCENARIO("container resolves automatic values", "[resolve]") {
         }
 
         WHEN("multiple dependencies are resolved") {
-            auto result1 = container.get(symbols::autoFizzUnique);
-            auto result2 = container.get(symbols::autoFizzUnique);
+            auto result1 = container.get<symbols::autoFizzUnique>();
+            auto result2 = container.get<symbols::autoFizzUnique>();
 
             result1->buzz();
             result2->buzz();
@@ -47,13 +47,13 @@ SCENARIO("container resolves automatic values", "[resolve]") {
     GIVEN("A container with automatic singleton shared_ptr binding") {
         inversify::Container container;
 
-        container.bind(symbols::foo).toConstantValue(10);
-        container.bind(symbols::bar).toConstantValue(1.618);
+        container.bind<symbols::foo>().toConstantValue(10);
+        container.bind<symbols::bar>().toConstantValue(1.618);
 
-        container.bind(symbols::autoFizzShared).to<Fizz>().inSingletonScope();
+        container.bind<symbols::autoFizzShared>().to<Fizz>().inSingletonScope();
 
         WHEN("the dependency is resolved") {
-            auto result = container.get(symbols::autoFizzShared);
+            auto result = container.get<symbols::autoFizzShared>();
             auto foo = result->buzz();
 
             THEN("the correct value is returned") {
@@ -63,8 +63,8 @@ SCENARIO("container resolves automatic values", "[resolve]") {
         }
 
         WHEN("multiple dependencies are resolved") {
-            auto result1 = container.get(symbols::autoFizzShared);
-            auto result2 = container.get(symbols::autoFizzShared);
+            auto result1 = container.get<symbols::autoFizzShared>();
+            auto result2 = container.get<symbols::autoFizzShared>();
 
             result1->buzz();
             result2->buzz();

--- a/test/constant_resolve.cpp
+++ b/test/constant_resolve.cpp
@@ -12,10 +12,10 @@ SCENARIO("container resolves constant values", "[resolve]") {
     GIVEN("A container with constant binding") {
         inversify::Container container;
 
-        container.bind(symbols::foo).toConstantValue(10);
+        container.bind<symbols::foo>().toConstantValue(10);
 
         WHEN("the dependency is resolved") {
-            auto result = container.get(symbols::foo);
+            auto result = container.get<symbols::foo>();
 
             THEN("the correct value is returned") {
                 REQUIRE(result == 10);
@@ -23,10 +23,10 @@ SCENARIO("container resolves constant values", "[resolve]") {
         }
 
         WHEN("the binding is redefined") {
-            container.bind(symbols::foo).toConstantValue(20);
+            container.bind<symbols::foo>().toConstantValue(20);
 
             WHEN("the dependency is resolved") {
-                auto result = container.get(symbols::foo);
+                auto result = container.get<symbols::foo>();
 
                 THEN("the updated value is returned") {
                     REQUIRE(result == 20);

--- a/test/dynamic_resolve.cpp
+++ b/test/dynamic_resolve.cpp
@@ -17,15 +17,15 @@ SCENARIO("container resolves dynamic values", "[resolve]") {
     GIVEN("A container with dynamic binding") {
         inversify::Container container;
 
-        container.bind(symbols::foo).toConstantValue(3);
-        container.bind(symbols::bar).toDynamicValue([](const inversify::Context& ctx) {
-            auto foo = ctx.container.get(symbols::foo);
+        container.bind<symbols::foo>().toConstantValue(3);
+        container.bind<symbols::bar>().toDynamicValue([](const inversify::Context& ctx) {
+            auto foo = ctx.container.get<symbols::foo>();
 
             return foo * 1.5;
         });
 
         WHEN("the dependency is resolved") {
-            auto result = container.get(symbols::bar);
+            auto result = container.get<symbols::bar>();
 
             THEN("the correct value is returned") {
                 REQUIRE(result == 4.5);
@@ -33,14 +33,14 @@ SCENARIO("container resolves dynamic values", "[resolve]") {
         }
 
         WHEN("the binding is redefined") {
-            container.bind(symbols::bar).toDynamicValue([](const inversify::Context& ctx) {
-                auto foo = ctx.container.get(symbols::foo);
+            container.bind<symbols::bar>().toDynamicValue([](const inversify::Context& ctx) {
+                auto foo = ctx.container.get<symbols::foo>();
 
                 return foo * 2.5;
             });
 
             WHEN("the dependency is resolved") {
-                auto result = container.get(symbols::bar);
+                auto result = container.get<symbols::bar>();
 
                 THEN("the updated value is returned") {
                     REQUIRE(result == 7.5);
@@ -52,14 +52,14 @@ SCENARIO("container resolves dynamic values", "[resolve]") {
     GIVEN("A container with factory binding") {
         inversify::Container container;
 
-        container.bind(symbols::foo).toConstantValue(10);
-        container.bind(symbols::bar).toConstantValue(1.618);
+        container.bind<symbols::foo>().toConstantValue(10);
+        container.bind<symbols::bar>().toConstantValue(1.618);
 
-        container.bind(symbols::fizzFactory).toDynamicValue(
+        container.bind<symbols::fizzFactory>().toDynamicValue(
             [](const inversify::Context& ctx) {
                 return [&]() {
-                    auto foo = ctx.container.get(symbols::foo);
-                    auto bar = ctx.container.get(symbols::bar);
+                    auto foo = ctx.container.get<symbols::foo>();
+                    auto bar = ctx.container.get<symbols::bar>();
 
                     auto fizz = std::make_unique<Fizz>(foo, bar);
 
@@ -69,7 +69,7 @@ SCENARIO("container resolves dynamic values", "[resolve]") {
         );
 
         WHEN("the dependency is resolved") {
-            auto factory = container.get(symbols::fizzFactory);
+            auto factory = container.get<symbols::fizzFactory>();
 
             WHEN("the factory is called") {
                 auto result = factory();
@@ -87,13 +87,13 @@ SCENARIO("container resolves dynamic values", "[resolve]") {
     GIVEN("A container with singleton dynamic binding") {
         inversify::Container container;
 
-        container.bind(symbols::foo).toConstantValue(10);
-        container.bind(symbols::bar).toConstantValue(1.618);
+        container.bind<symbols::foo>().toConstantValue(10);
+        container.bind<symbols::bar>().toConstantValue(1.618);
 
-        container.bind(symbols::fizz).toDynamicValue(
+        container.bind<symbols::fizz>().toDynamicValue(
             [](const inversify::Context& ctx) {
-                auto foo = ctx.container.get(symbols::foo);
-                auto bar = ctx.container.get(symbols::bar);
+                auto foo = ctx.container.get<symbols::foo>();
+                auto bar = ctx.container.get<symbols::bar>();
 
                 auto fizz = std::make_shared<Fizz>(foo, bar);
 
@@ -102,8 +102,8 @@ SCENARIO("container resolves dynamic values", "[resolve]") {
         ).inSingletonScope();
 
         WHEN("multiple dependencies are resolved") {
-            auto fizz1 = container.get(symbols::fizz);
-            auto fizz2 = container.get(symbols::fizz);
+            auto fizz1 = container.get<symbols::fizz>();
+            auto fizz2 = container.get<symbols::fizz>();
 
             THEN("both dependency pointers are equal") {
                 REQUIRE(fizz1 == fizz2);
@@ -114,13 +114,13 @@ SCENARIO("container resolves dynamic values", "[resolve]") {
     GIVEN("A container with resolution dynamic binding") {
         inversify::Container container;
 
-        container.bind(symbols::foo).toConstantValue(10);
-        container.bind(symbols::bar).toConstantValue(1.618);
+        container.bind<symbols::foo>().toConstantValue(10);
+        container.bind<symbols::bar>().toConstantValue(1.618);
 
-        container.bind(symbols::fizz).toDynamicValue(
+        container.bind<symbols::fizz>().toDynamicValue(
             [](const inversify::Context& ctx) {
-                auto foo = ctx.container.get(symbols::foo);
-                auto bar = ctx.container.get(symbols::bar);
+                auto foo = ctx.container.get<symbols::foo>();
+                auto bar = ctx.container.get<symbols::bar>();
 
                 auto fizz = std::make_unique<Fizz>(foo, bar);
 
@@ -129,8 +129,8 @@ SCENARIO("container resolves dynamic values", "[resolve]") {
         );
 
         WHEN("multiple dependencies are resolved") {
-            auto fizz1 = container.get(symbols::fizz);
-            auto fizz2 = container.get(symbols::fizz);
+            auto fizz1 = container.get<symbols::fizz>();
+            auto fizz2 = container.get<symbols::fizz>();
 
             THEN("dependencies are unique") {
                 REQUIRE(fizz1 != fizz2);

--- a/test/mock/fizz.hpp
+++ b/test/mock/fizz.hpp
@@ -25,7 +25,10 @@ struct Fizz : IFizz {
     double bar_;
 };
 
-inline static auto _ = inversify::Injectable<Fizz>::inject(
-    symbols::foo,
-    symbols::bar
-);
+template <>
+struct inversify::Injectable<Fizz> {
+    using Inject = inversify::Inject<
+        symbols::foo,
+        symbols::bar
+    >;
+};

--- a/test/mock/symbols.hpp
+++ b/test/mock/symbols.hpp
@@ -10,11 +10,11 @@
 namespace inversify = mosure::inversify;
 
 namespace symbols {
-    inline extern inversify::Symbol<int> foo {};
-    inline extern inversify::Symbol<double> bar {};
-    inline extern inversify::Symbol<IFizzSharedPtr> fizz {};
-    inline extern inversify::Symbol<std::function<IFizzUniquePtr()>> fizzFactory {};
+    using foo = inversify::Symbol<int>;
+    using bar = inversify::Symbol<double>;
+    using fizz = inversify::Symbol<IFizzSharedPtr>;
+    using fizzFactory = inversify::Symbol<std::function<IFizzUniquePtr()>>;
 
-    inline extern inversify::Symbol<IFizzUniquePtr> autoFizzUnique {};
-    inline extern inversify::Symbol<IFizzSharedPtr> autoFizzShared {};
+    using autoFizzUnique = inversify::Symbol<IFizzUniquePtr>;
+    using autoFizzShared = inversify::Symbol<IFizzSharedPtr>;
 }


### PR DESCRIPTION
this change was done to lower runtime overhead and support the [templated http API](https://github.com/mosure/rest-server-inversify-cpp)