### PR TITLE
fix: dependency tuple initialization

### DIFF
--- a/include/mosure/resolver.hpp
+++ b/include/mosure/resolver.hpp
@@ -26,7 +26,7 @@ struct Dependency {
 
     operator bool() { return dependent; }
 
-    bool dependent;
+    bool dependent { false };
 };
 
 template <typename... SymbolTypes>

--- a/single_include/mosure/inversify.hpp
+++ b/single_include/mosure/inversify.hpp
@@ -265,7 +265,7 @@ struct Dependency {
 
     operator bool() { return dependent; }
 
-    bool dependent;
+    bool dependent { false };
 };
 
 template <typename... SymbolTypes>


### PR DESCRIPTION
## Summary
- ensure `Dependency` structs start with flags set to `false`

## Testing
- `g++ build/*.o -pthread -o build/tests && ./build/tests`