### PR TITLE
Add resolution scoped dependency caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See the [inversify-cpp-visualizer](https://github.com/mosure/inversify-cpp-visua
 
 ## Features
 *   Constant, dynamic, and automatic resolvers
-*   Singleton, resolution (TODO), and unique scopes
+*   Singleton, resolution, and unique scopes
 
 ## Documentation
 
@@ -142,11 +142,24 @@ container.bind<symbols::bar>().toConstantValue(1.618);
 
 Dynamic bindings are resolved when calling `container.get...`.
 
-By default, dynamic bindings have resolution scope (e.g. each call to `container.get...` calls the factory).
+By default, dynamic bindings have unique scope (e.g. each call to `container.get...` calls the factory).
 
-Singleton scope dynamic bindings cache the first resolution of the binding.
+Resolution scope dynamic bindings cache values during a single resolution graph, ensuring duplicate dependencies resolve to the same value. Use `.inResolutionScope()` to enable this behaviour.
+
+Singleton scope dynamic bindings cache the first resolution of the binding across all calls.
 
 ```cpp
+
+container.bind<symbols::fizz>().toDynamicValue(
+    [](auto& ctx) {
+        auto foo = ctx.container.template get<symbols::foo>();
+        auto bar = ctx.container.template get<symbols::bar>();
+
+        auto fizz = std::make_shared<Fizz>(foo, bar);
+
+        return fizz;
+    }
+).inResolutionScope();
 
 container.bind<symbols::fizz>().toDynamicValue(
     [](auto& ctx) {

--- a/example/simple/src/main.cpp
+++ b/example/simple/src/main.cpp
@@ -1,3 +1,7 @@
+#include <iostream>
+#include <memory>
+#include <utility>
+
 #include <mosure/inversify.hpp>
 
 #include <api/symbols.hpp>
@@ -10,20 +14,51 @@
 
 namespace inversify = mosure::inversify;
 
+struct RequestLog {
+    RequestLog(ILoggerPtr primary, ILoggerPtr secondary)
+        : primary_(std::move(primary)), secondary_(std::move(secondary))
+    { }
+
+    ILoggerPtr primary_;
+    ILoggerPtr secondary_;
+};
+
+using RequestLogPtr = std::shared_ptr<RequestLog>;
+
+namespace request_symbols {
+    using batchedLog = inversify::Symbol<RequestLogPtr>;
+}
+
+template <>
+struct inversify::Injectable<RequestLog>
+    : inversify::Inject<
+        symbols::logger,
+        symbols::logger
+    >
+{ };
+
 int main() {
     inversify::Container<
         symbols::logger,
         symbols::service,
-        symbols::settings
+        symbols::settings,
+        request_symbols::batchedLog
     > container;
 
-    container.bind<symbols::logger>().to<Logger>().inSingletonScope();
+    container.bind<symbols::logger>().to<Logger>().inResolutionScope();
     container.bind<symbols::service>().to<Service>();
     container.bind<symbols::settings>().to<Settings>().inSingletonScope();
+    container.bind<request_symbols::batchedLog>().to<RequestLog>();
 
     //container.bind<ILoggerPtr>(symbols::logger).to<MockLogger>().inSingletonScope();
 
     container.get<symbols::service>()->run();
+
+    auto requestLog = container.get<request_symbols::batchedLog>();
+    std::cout << std::boolalpha
+              << "Resolution scoped logger reused within request: "
+              << (requestLog->primary_ == requestLog->secondary_)
+              << std::endl;
 
     return 0;
 }

--- a/include/mosure/binding.hpp
+++ b/include/mosure/binding.hpp
@@ -18,6 +18,10 @@ public:
         resolver_ = std::make_shared<inversify::CachedResolver<T, SymbolTypes...>>(resolver_);
     }
 
+    void inResolutionScope() {
+        resolver_ = std::make_shared<inversify::ResolutionCachedResolver<T, SymbolTypes...>>(resolver_);
+    }
+
 #ifdef INVERSIFY_BINDING_INSPECTION
     auto getResolver() const {
         return resolver_;

--- a/include/mosure/container.hpp
+++ b/include/mosure/container.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <tuple>
 
 #include <mosure/binding.hpp>
@@ -51,9 +52,21 @@ public:
             "inversify::Container symbol not registered"
         );
 
-        return std::get<
+        auto* previousScope = context_.resolutionScope;
+        std::optional<inversify::ResolutionScope> scope;
+
+        if (previousScope == nullptr) {
+            scope.emplace();
+            context_.resolutionScope = &scope.value();
+        }
+
+        auto result = std::get<
             inversify::Binding<T, SymbolTypes...>
         >(bindings_).resolve(context_);
+
+        context_.resolutionScope = previousScope;
+
+        return result;
     }
 
 private:

--- a/include/mosure/context.hpp
+++ b/include/mosure/context.hpp
@@ -1,9 +1,52 @@
 #pragma once
 
+#include <memory>
+#include <unordered_map>
+#include <utility>
+
 #include <mosure/interfaces/icontainer.hpp>
 
 
 namespace mosure::inversify {
+
+class ResolutionScope {
+    struct CacheEntry {
+        virtual ~CacheEntry() = default;
+    };
+
+    template <typename T>
+    struct CacheValue : CacheEntry {
+        explicit CacheValue(T value)
+            : value_(std::move(value))
+        { }
+
+        const T& value() const { return value_; }
+
+    private:
+        T value_;
+    };
+
+public:
+    template <typename T>
+    bool contains(const void* key) const {
+        return cache_.find(key) != cache_.end();
+    }
+
+    template <typename T>
+    T get(const void* key) const {
+        return static_cast<CacheValue<T>*>(cache_.at(key).get())->value();
+    }
+
+    template <typename T>
+    void set(const void* key, T value) {
+        cache_[key] = std::make_unique<CacheValue<T>>(std::move(value));
+    }
+
+    void clear() { cache_.clear(); }
+
+private:
+    std::unordered_map<const void*, std::unique_ptr<CacheEntry>> cache_;
+};
 
 template <typename... SymbolTypes>
 class Container;
@@ -11,6 +54,7 @@ class Container;
 template <typename... SymbolTypes>
 struct Context {
     inversify::IContainer<Container, SymbolTypes...>& container;
+    ResolutionScope* resolutionScope { nullptr };
 };
 
 }

--- a/include/mosure/resolver.hpp
+++ b/include/mosure/resolver.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 #ifdef INVERSIFY_BINDING_INSPECTION
 #include <string>
@@ -265,6 +266,54 @@ public:
 private:
     T cached_;
     std::atomic<bool> hasCached_ { false };
+    ResolverPtr<T, SymbolTypes...> parent_;
+};
+
+template <
+    typename T,
+    typename... SymbolTypes
+>
+class ResolutionCachedResolver
+    : public Resolver<T, SymbolTypes...> {
+    static_assert(
+        std::is_copy_constructible_v<T>,
+        "inversify::ResolutionCachedResolver requires a copy constructor. Are you caching a unique_ptr?"
+    );
+
+public:
+    explicit ResolutionCachedResolver(ResolverPtr<T, SymbolTypes...> parent)
+        : parent_(std::move(parent))
+    { }
+
+    inline T resolve(const inversify::Context<SymbolTypes...>& context) override {
+        if (!context.resolutionScope) {
+            return parent_->resolve(context);
+        }
+
+        auto key = static_cast<const void*>(this);
+        auto& scope = *context.resolutionScope;
+
+        if (scope.template contains<T>(key)) {
+            return scope.template get<T>(key);
+        }
+
+        auto value = parent_->resolve(context);
+        scope.template set<T>(key, value);
+
+        return value;
+    }
+
+#ifdef INVERSIFY_BINDING_INSPECTION
+    inline virtual std::string getResolverLabel() const override {
+        return std::string("resolution - ") + parent_->getResolverLabel();
+    }
+
+    inline virtual std::string getImplementationLabel() const override {
+        return parent_->getImplementationLabel();
+    }
+#endif
+
+private:
     ResolverPtr<T, SymbolTypes...> parent_;
 };
 

--- a/single_include/mosure/inversify.hpp
+++ b/single_include/mosure/inversify.hpp
@@ -33,7 +33,9 @@ SOFTWARE.
 #include <stdexcept>        // runtime_error
 #include <string>           // string
 #include <tuple>            // make_from_tuple, tuple
+#include <optional>         // optional
 #include <type_traits>      // apply, conjunction_v, disjunction_v, false_type, is_copy_constructable, is_same, true_type
+#include <unordered_map>    // unordered_map
 
 // #include <mosure/binding.hpp>
 
@@ -107,12 +109,52 @@ public:
 
 namespace mosure::inversify {
 
+class ResolutionScope {
+    struct CacheEntry {
+        virtual ~CacheEntry() = default;
+    };
+
+    template <typename T>
+    struct CacheValue : CacheEntry {
+        explicit CacheValue(T value)
+            : value_(std::move(value))
+        { }
+
+        const T& value() const { return value_; }
+
+    private:
+        T value_;
+    };
+
+public:
+    template <typename T>
+    bool contains(const void* key) const {
+        return cache_.find(key) != cache_.end();
+    }
+
+    template <typename T>
+    T get(const void* key) const {
+        return static_cast<CacheValue<T>*>(cache_.at(key).get())->value();
+    }
+
+    template <typename T>
+    void set(const void* key, T value) {
+        cache_[key] = std::make_unique<CacheValue<T>>(std::move(value));
+    }
+
+    void clear() { cache_.clear(); }
+
+private:
+    std::unordered_map<const void*, std::unique_ptr<CacheEntry>> cache_;
+};
+
 template <typename... SymbolTypes>
 class Container;
 
 template <typename... SymbolTypes>
 struct Context {
     inversify::IContainer<Container, SymbolTypes...>& container;
+    ResolutionScope* resolutionScope { nullptr };
 };
 
 }
@@ -507,6 +549,54 @@ private:
     ResolverPtr<T, SymbolTypes...> parent_;
 };
 
+template <
+    typename T,
+    typename... SymbolTypes
+>
+class ResolutionCachedResolver
+    : public Resolver<T, SymbolTypes...> {
+    static_assert(
+        std::is_copy_constructible_v<T>,
+        "inversify::ResolutionCachedResolver requires a copy constructor. Are you caching a unique_ptr?"
+    );
+
+public:
+    explicit ResolutionCachedResolver(ResolverPtr<T, SymbolTypes...> parent)
+        : parent_(std::move(parent))
+    { }
+
+    inline T resolve(const inversify::Context<SymbolTypes...>& context) override {
+        if (!context.resolutionScope) {
+            return parent_->resolve(context);
+        }
+
+        auto key = static_cast<const void*>(this);
+        auto& scope = *context.resolutionScope;
+
+        if (scope.template contains<T>(key)) {
+            return scope.template get<T>(key);
+        }
+
+        auto value = parent_->resolve(context);
+        scope.template set<T>(key, value);
+
+        return value;
+    }
+
+#ifdef INVERSIFY_BINDING_INSPECTION
+    inline virtual std::string getResolverLabel() const override {
+        return std::string("resolution - ") + parent_->getResolverLabel();
+    }
+
+    inline virtual std::string getImplementationLabel() const override {
+        return parent_->getImplementationLabel();
+    }
+#endif
+
+private:
+    ResolverPtr<T, SymbolTypes...> parent_;
+};
+
 }
 
 // #include <mosure/exceptions/resolution.hpp>
@@ -520,6 +610,10 @@ class BindingScope {
 public:
     void inSingletonScope() {
         resolver_ = std::make_shared<inversify::CachedResolver<T, SymbolTypes...>>(resolver_);
+    }
+
+    void inResolutionScope() {
+        resolver_ = std::make_shared<inversify::ResolutionCachedResolver<T, SymbolTypes...>>(resolver_);
     }
 
 #ifdef INVERSIFY_BINDING_INSPECTION
@@ -629,9 +723,21 @@ public:
             "inversify::Container symbol not registered"
         );
 
-        return std::get<
+        auto* previousScope = context_.resolutionScope;
+        std::optional<inversify::ResolutionScope> scope;
+
+        if (previousScope == nullptr) {
+            scope.emplace();
+            context_.resolutionScope = &scope.value();
+        }
+
+        auto result = std::get<
             inversify::Binding<T, SymbolTypes...>
         >(bindings_).resolve(context_);
+
+        context_.resolutionScope = previousScope;
+
+        return result;
     }
 
 private:

--- a/test/dynamic_resolve.cpp
+++ b/test/dynamic_resolve.cpp
@@ -1,5 +1,6 @@
 #include <functional>
 #include <memory>
+#include <utility>
 
 #define CATCH_CONFIG_ENABLE_BENCHMARKING
 #include <catch2/catch.hpp>
@@ -11,6 +12,36 @@
 
 
 namespace inversify = mosure::inversify;
+
+struct ResolutionDependency {
+    explicit ResolutionDependency(int value) : value(value) { }
+
+    int value;
+};
+using ResolutionDependencyPtr = std::shared_ptr<ResolutionDependency>;
+
+struct ResolutionConsumer {
+    ResolutionConsumer(ResolutionDependencyPtr first, ResolutionDependencyPtr second)
+        : first(std::move(first)), second(std::move(second))
+    { }
+
+    ResolutionDependencyPtr first;
+    ResolutionDependencyPtr second;
+};
+using ResolutionConsumerPtr = std::shared_ptr<ResolutionConsumer>;
+
+namespace resolution_symbols {
+    using dependency = inversify::Symbol<ResolutionDependencyPtr>;
+    using consumer = inversify::Symbol<ResolutionConsumerPtr>;
+}
+
+template <>
+struct inversify::Injectable<ResolutionConsumer>
+    : inversify::Inject<
+        resolution_symbols::dependency,
+        resolution_symbols::dependency
+    >
+{ };
 
 SCENARIO("container resolves dynamic values", "[resolve]") {
 
@@ -154,6 +185,44 @@ SCENARIO("container resolves dynamic values", "[resolve]") {
 
             THEN("dependencies are unique") {
                 REQUIRE(fizz1 != fizz2);
+            }
+        }
+    }
+
+    GIVEN("A container with a resolution scoped dynamic binding") {
+        inversify::Container<
+            symbols::foo,
+            resolution_symbols::dependency,
+            resolution_symbols::consumer
+        > container;
+
+        container.bind<symbols::foo>().toConstantValue(10);
+
+        int factoryCount = 0;
+        container.bind<resolution_symbols::dependency>().toDynamicValue(
+            [&](auto& ctx) {
+                ++factoryCount;
+                auto foo = ctx.container.template get<symbols::foo>();
+
+                return std::make_shared<ResolutionDependency>(foo);
+            }
+        ).inResolutionScope();
+
+        container.bind<resolution_symbols::consumer>().to<ResolutionConsumer>();
+
+        WHEN("a graph resolves the dependency twice") {
+            auto consumer = container.get<resolution_symbols::consumer>();
+
+            THEN("the same dependency instance is reused within the graph") {
+                REQUIRE(consumer->first == consumer->second);
+                REQUIRE(factoryCount == 1);
+
+                AND_THEN("a new graph receives a new instance") {
+                    auto next = container.get<resolution_symbols::consumer>();
+
+                    REQUIRE(next->first != consumer->first);
+                    REQUIRE(factoryCount == 2);
+                }
             }
         }
     }

--- a/test/speed.cpp
+++ b/test/speed.cpp
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <iostream>
 #include <memory>
+#include <utility>
 
 #define CATCH_CONFIG_ENABLE_BENCHMARKING
 #include <catch2/catch.hpp>
@@ -12,6 +13,28 @@
 
 
 namespace inversify = mosure::inversify;
+
+struct ScopedAggregator {
+    ScopedAggregator(ServiceAPtr first, ServiceAPtr second)
+        : first_(std::move(first)), second_(std::move(second))
+    { }
+
+    ServiceAPtr first_;
+    ServiceAPtr second_;
+};
+using ScopedAggregatorPtr = std::shared_ptr<ScopedAggregator>;
+
+namespace speed_symbols {
+    using aggregator = inversify::Symbol<ScopedAggregatorPtr>;
+}
+
+template <>
+struct inversify::Injectable<ScopedAggregator>
+    : inversify::Inject<
+        symbols::symbolA,
+        symbols::symbolA
+    >
+{ };
 
 SCENARIO("container resolves automatic values quickly", "[performance]") {
 
@@ -40,6 +63,22 @@ SCENARIO("container resolves automatic values quickly", "[performance]") {
                     )
                 )
             );
+        };
+    }
+
+    GIVEN("A container with resolution scoped reuse within a graph") {
+        inversify::Container<
+            symbols::foo,
+            symbols::symbolA,
+            speed_symbols::aggregator
+        > container;
+
+        container.bind<symbols::foo>().toConstantValue(10);
+        container.bind<symbols::symbolA>().to<ServiceA>().inResolutionScope();
+        container.bind<speed_symbols::aggregator>().to<ScopedAggregator>();
+
+        BENCHMARK("resolution scoped aggregator") {
+            return container.get<speed_symbols::aggregator>();
         };
     }
 }


### PR DESCRIPTION
## Summary
- introduce a resolution-scope cache and resolver wrapper so bindings can reuse instances within a single resolution graph
- document and demonstrate the new scope in the README and example application, and add targeted unit tests and benchmarks

## Testing
- bazel test //:test *(fails to complete locally: Bazel invocation hung without producing output)*

------
https://chatgpt.com/codex/tasks/task_e_68dddb78bf04832bacecf10aad6dc405